### PR TITLE
Use srcDir option to search sources

### DIFF
--- a/godbg.go
+++ b/godbg.go
@@ -602,24 +602,28 @@ func addFrameHandlers(mygdb *gdblib.GDB) {
 			return
 		}
 
-		path, err = filepath.Abs(path)
+		if *srcDir != "" {
+			path = *srcDir + "/" + strings.Replace(path, "../", "", -1)
+		} else {
+			path, err = filepath.Abs(path)
 
-		inGopath := false
-		for _, p := range gopaths {
-			if strings.HasPrefix(path, p) {
-				inGopath = true
-				break
+			inGopath := false
+			for _, p := range gopaths {
+				if strings.HasPrefix(path, p) {
+					inGopath = true
+					break
+				}
 			}
-		}
 
-		// If the path is not under the current directory or in the GOPATH/GOROOT then it is an illegal access
-		if !inGopath &&
-			!strings.HasPrefix(path, cwd) &&
-			!strings.HasPrefix(path, goroot) {
+			// If the path is not under the current directory or in the GOPATH/GOROOT then it is an illegal access
+			if !inGopath &&
+				!strings.HasPrefix(path, cwd) &&
+				!strings.HasPrefix(path, goroot) {
 
-			w.WriteHeader(400)
-			w.Write([]byte("Illegal file access"))
-			return
+				w.WriteHeader(400)
+				w.Write([]byte("Illegal file access"))
+				return
+			}
 		}
 
 		file, err := os.Open(path)

--- a/godbg.go
+++ b/godbg.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/sirnewton01/gdblib"
+	"github.com/albfan/gdblib"
 	"go/build"
 	"io"
 	"log"
@@ -60,6 +60,7 @@ const (
 
 var (
 	srcDir    *string
+	sudo      *bool
 	autoOpen  *bool
 	gopath    string
 	gopaths   []string
@@ -79,6 +80,7 @@ func init() {
 		flag.PrintDefaults()
 	}
 	srcDir = flag.String("srcDir", "", "Location of the source code for the executable")
+	sudo = flag.Bool("sudo", false, "Launch debugger as root")
 	autoOpen = flag.Bool("openBrowser", true, "Automatically open a web browser when possible")
 
 	flag.Parse()
@@ -178,7 +180,7 @@ func main() {
 		}
 	}
 
-	mygdb, err := gdblib.NewGDB(execPath, *srcDir)
+	mygdb, err := gdblib.NewGDB(execPath, *srcDir, *sudo)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Debugging C/C++ apps, code is not under GOPATH, so use srcDir option to find it.

for non trivial programs, they must be installed, so "../" on source code path is removed to allow delelopers to provide root directory of sources.
